### PR TITLE
build(docker): switch to .env.docker for environment variables

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -1,0 +1,5 @@
+NODE_ENV=development
+REDIS_HOST=redis
+REDIS_PORT=6379
+LOG_LEVEL=debug
+BROWSER_HEADLESS=false

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - redis
     env_file:
-      - .env   #自动加载 .env 文件里的变量
+      - .env.docker   # 自动加载 .env.docker 文件里的变量
 
   redis:
     image: redis:7.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,16 +6,8 @@ services:
       context: .
       target: base # 使用基础镜像进行开发
     command: npm run dev
-    volumes:
-      - .:/home/appuser/app:cached
-    ports:
-      - "3000:3000"
-    environment:
-      - NODE_ENV=development
-      - REDIS_HOST=redis
-      - REDIS_PORT=6379
-      - LOG_LEVEL=debug
-      - BROWSER_HEADLESS=false
+    env_file:
+      - .env.docker
     depends_on:
       - redis
     healthcheck:
@@ -46,8 +38,6 @@ services:
 
   redis:
     image: redis:7-alpine
-    ports:
-      - "6379:6379"
     volumes:
       - redis-data:/data
     healthcheck:


### PR DESCRIPTION
Move environment variables from docker-compose files to .env.docker for better configuration management and maintainability. Remove redundant port mappings and simplify service configurations.