### PR TITLE
chore(config): integrate Playwright test and reporting configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dist
 examples
 
 target
+
+playwright-report

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "playwright-runner",
       "version": "1.0.0",
       "dependencies": {
+        "@playwright/test": "^1.39.0",
         "@types/express": "^4.17.17",
         "bullmq": "^5.6.2",
         "dotenv": "^16.3.1",
@@ -1231,6 +1232,20 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -5101,11 +5116,11 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.54.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
-      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
       "dependencies": {
-        "playwright-core": "1.54.2"
+        "playwright-core": "1.55.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5118,9 +5133,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.54.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
-      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -9,11 +9,14 @@
     "start": "node dist/index.js",
     "test": "jest",
     "test:watch": "jest --watch",
+    "test:report": "ts-node test-report.ts",
+    "report:open": "node scripts/open-report.js",
     "lint": "eslint 'src/**/*.{js,ts}'",
     "format": "prettier --write 'src/**/*.{js,ts}'",
     "prepare": "husky install"
   },
   "dependencies": {
+    "@playwright/test": "^1.39.0",
     "@types/express": "^4.17.17",
     "bullmq": "^5.6.2",
     "dotenv": "^16.3.1",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,6 +1,7 @@
 import dotenv from 'dotenv';
 import { QUEUE_CONFIG, QueueConfig } from './queue';
 import { BROWSER_CONFIG, BrowserConfig } from './browser';
+import { REPORT_CONFIG, ReportConfig } from './report';
 
 // Load environment variables
 dotenv.config();
@@ -15,12 +16,14 @@ export const BASE_CONFIG = {
 // Export other module configurations
 export { QUEUE_CONFIG } from './queue';
 export { BROWSER_CONFIG } from './browser';
+export { REPORT_CONFIG } from './report';
 
 // Aggregate all configurations
 export const CONFIG = {
   ...BASE_CONFIG,
   queue: QUEUE_CONFIG,
   browser: BROWSER_CONFIG,
+  report: REPORT_CONFIG,
 };
 
 export default CONFIG;


### PR DESCRIPTION
- Add @playwright/test dependency and update Playwright packages to version 1.55.0
- Include playwright-report folder in .gitignore to exclude test reports
- Add test:report and report:open scripts for generating and viewing test reports
- Import and export REPORT_CONFIG in main configuration index
- Extend aggregated config object to include report configuration section